### PR TITLE
Add internship CRUD and application soft delete

### DIFF
--- a/internish/urls.py
+++ b/internish/urls.py
@@ -4,6 +4,7 @@ from auth_app.urls import router as auth_router
 from user_app.urls import router as user_router
 from institution_app.urls import institution_router_private
 from application_app.urls import router as application_router
+from internship_app.urls import router as internship_router
 
 router = APIRouter()
 
@@ -11,6 +12,7 @@ router.include_router(auth_router)
 router.include_router(user_router)
 router.include_router(institution_router_private)
 router.include_router(application_router)
+router.include_router(internship_router)
 
 
 @router.get("/")

--- a/internship_app/schemas.py
+++ b/internship_app/schemas.py
@@ -1,0 +1,16 @@
+from typing import Annotated, Optional
+from datetime import date
+
+from pydantic import BaseModel, Field, StringConstraints
+
+
+class Internship(BaseModel):
+    id_: Optional[int] = None
+    application_id_: Annotated[int, Field(gt=0)]
+    supervisor_id_: Optional[int] = None
+    start_date_: Optional[date] = None
+    end_date_: Optional[date] = None
+    status_: Annotated[
+        str,
+        StringConstraints(pattern=r"^(ongoing|completed|cancelled)$"),
+    ] | None = None

--- a/internship_app/urls.py
+++ b/internship_app/urls.py
@@ -1,0 +1,70 @@
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from internish.security import require_auth
+from internship_app.schemas import Internship
+from internship_app.views import internship_interact
+
+router = APIRouter(prefix="/internships", tags=["internships"])
+
+
+@router.get("/")
+def list_internships(
+    limit: int = Query(10, ge=1, le=100, description="Items per page"),
+    offset: int = Query(0, ge=0, description="Skip N items"),
+    current=Depends(require_auth),
+):
+    student_id = None
+    if current["role"] == "student":
+        student_id = internship_interact.get_student_id_by_email(current["email"])
+    return internship_interact.list(student_id=student_id, limit=limit, offset=offset)
+
+
+@router.get("/{internship_id}")
+def get_internship(internship_id: int, current=Depends(require_auth)):
+    student_id = None
+    if current["role"] == "student":
+        student_id = internship_interact.get_student_id_by_email(current["email"])
+    data = internship_interact.detail(internship_id, student_id=student_id)
+    if data is None:
+        raise HTTPException(status_code=404, detail="Internship not found")
+    return data
+
+
+@router.post("/")
+def create_internship(internship: Internship, current=Depends(require_auth)):
+    student_id = None
+    if current["role"] == "student":
+        student_id = internship_interact.get_student_id_by_email(current["email"])
+    try:
+        result = internship_interact.v_create(internship, student_id=student_id)
+    except Exception as e:
+        raise HTTPException(status_code=400, detail={"status": False, "message": f"Error: {str(e)}"})
+    return {"status_code": 200, "detail": {"status": result, "message": "Internship created successfully"}}
+
+
+@router.put("/{internship_id}")
+def update_internship(internship_id: int, internship: Internship, current=Depends(require_auth)):
+    student_id = None
+    if current["role"] == "student":
+        student_id = internship_interact.get_student_id_by_email(current["email"])
+    try:
+        result = internship_interact.v_update(internship_id, internship, student_id=student_id)
+    except Exception as e:
+        raise HTTPException(status_code=400, detail={"status": False, "message": f"Error: {str(e)}"})
+    if not result:
+        raise HTTPException(status_code=404, detail="Internship not found")
+    return {"status_code": 200, "detail": {"status": True, "message": "Internship updated successfully"}}
+
+
+@router.delete("/{internship_id}")
+def delete_internship(internship_id: int, current=Depends(require_auth)):
+    student_id = None
+    if current["role"] == "student":
+        student_id = internship_interact.get_student_id_by_email(current["email"])
+    try:
+        result = internship_interact.v_delete(internship_id, student_id=student_id)
+    except Exception as e:
+        raise HTTPException(status_code=400, detail={"status": False, "message": f"Error: {str(e)}"})
+    if not result:
+        raise HTTPException(status_code=404, detail="Internship not found")
+    return {"status_code": 200, "detail": {"status": True, "message": "Internship deleted successfully"}}

--- a/internship_app/views.py
+++ b/internship_app/views.py
@@ -1,0 +1,165 @@
+from internish.connect import PostgresConnection
+
+
+class InternshipInteract(PostgresConnection):
+    def get_student_id_by_email(self, email: str):
+        query = """
+        SELECT students.id_
+        FROM users
+        JOIN students ON students.user_id_ = users.id_
+        WHERE LOWER(users.email_) = LOWER(%(email)s)
+        LIMIT 1;
+        """
+        row = self.fetchone(query, {"email": email})
+        return row["id_"] if row else None
+
+    def _check_application(self, application_id, student_id=None):
+        query = """
+        SELECT student_id_, status_, deleted_at_
+        FROM applications
+        WHERE id_ = %(id)s
+        LIMIT 1;
+        """
+        row = self.fetchone(query, {"id": application_id})
+        if row is None:
+            raise Exception("Application not found")
+        if row["status_"] != "accepted" or row["deleted_at_"] is not None:
+            raise Exception("Application must be accepted and active")
+        if student_id is not None and row["student_id_"] != student_id:
+            raise Exception("Forbidden")
+        return True
+
+    def list(self, student_id=None, limit=10, offset=0):
+        query = """
+        SELECT
+        json_build_object(
+            'id_',         i.id_,
+            'application_id_', i.application_id_,
+            'supervisor_id_', i.supervisor_id_,
+            'start_date_', i.start_date_,
+            'end_date_',   i.end_date_,
+            'status_',     i.status_
+        ) AS data,
+        COUNT(*) OVER() AS total
+        FROM internships i
+        JOIN applications a ON a.id_ = i.application_id_
+        WHERE a.deleted_at_ IS NULL
+          AND (%(student_id)s IS NULL OR a.student_id_ = %(student_id)s)
+        ORDER BY i.id_ DESC
+        LIMIT %(limit)s OFFSET %(offset)s;
+        """
+        rows = self.fetchall(query, {"student_id": student_id, "limit": limit, "offset": offset})
+        items = [row["data"] for row in rows]
+        total = rows[0]["total"] if rows else 0
+        from_idx = (offset + 1) if total > 0 else 0
+        to_idx = min(offset + limit, total)
+        has_next = (offset + limit) < total
+        has_prev = offset > 0
+        return {
+            "items": items,
+            "total": total,
+            "limit": limit,
+            "offset": offset,
+            "from": from_idx,
+            "to": to_idx,
+            "has_next": has_next,
+            "has_prev": has_prev,
+            "next_offset": (offset + limit) if has_next else None,
+            "prev_offset": max(offset - limit, 0) if has_prev else None,
+        }
+
+    def detail(self, internship_id, student_id=None):
+        query = """
+        SELECT json_build_object(
+            'id_',         i.id_,
+            'application_id_', i.application_id_,
+            'supervisor_id_', i.supervisor_id_,
+            'start_date_', i.start_date_,
+            'end_date_',   i.end_date_,
+            'status_',     i.status_
+        ) AS data
+        FROM internships i
+        JOIN applications a ON a.id_ = i.application_id_
+        WHERE i.id_ = %(id)s
+          AND a.deleted_at_ IS NULL
+          AND (%(student_id)s IS NULL OR a.student_id_ = %(student_id)s)
+        LIMIT 1;
+        """
+        rows = self.fetchall(query, {"id": internship_id, "student_id": student_id})
+        return rows[0]["data"] if rows else None
+
+    def v_create(self, internship, student_id=None):
+        self._check_application(internship.application_id_, student_id)
+        query = """
+        INSERT INTO internships (application_id_, supervisor_id_, start_date_, end_date_, status_)
+        VALUES (%(application_id)s, %(supervisor_id)s, %(start_date)s, %(end_date)s, %(status)s)
+        RETURNING id_;
+        """
+        result = self.insert(
+            query,
+            {
+                "application_id": internship.application_id_,
+                "supervisor_id": internship.supervisor_id_,
+                "start_date": internship.start_date_,
+                "end_date": internship.end_date_,
+                "status": internship.status_,
+            },
+        )
+        return result is not None
+
+    def v_update(self, internship_id, internship, student_id=None):
+        existing = self.fetchone(
+            """
+            SELECT i.application_id_
+            FROM internships i
+            WHERE i.id_ = %(id)s
+            """,
+            {"id": internship_id},
+        )
+        if existing is None:
+            return False
+        self._check_application(existing["application_id_"] , student_id)
+        query = """
+        UPDATE internships
+        SET
+            supervisor_id_ = %(supervisor_id)s,
+            start_date_ = %(start_date)s,
+            end_date_ = %(end_date)s,
+            status_ = COALESCE(%(status)s, status_)
+        WHERE id_ = %(id)s
+        RETURNING id_;
+        """
+        result = self.update(
+            query,
+            {
+                "id": internship_id,
+                "supervisor_id": internship.supervisor_id_,
+                "start_date": internship.start_date_,
+                "end_date": internship.end_date_,
+                "status": internship.status_,
+            },
+        )
+        return result is not None
+
+    def v_delete(self, internship_id, student_id=None):
+        existing = self.fetchone(
+            """
+            SELECT i.application_id_
+            FROM internships i
+            WHERE i.id_ = %(id)s
+            """,
+            {"id": internship_id},
+        )
+        if existing is None:
+            return False
+        self._check_application(existing["application_id_"] , student_id)
+        query = """
+        DELETE FROM internships
+        WHERE id_ = %(id)s
+        RETURNING id_;
+        """
+        result = self.update(query, {"id": internship_id})
+        return result is not None
+
+
+internship_interact = InternshipInteract()


### PR DESCRIPTION
## Summary
- implement internship CRUD routes with checks that source application is accepted
- switch applications to soft delete and filter listings to active records
- expose internship endpoints via main router

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac72be80d083319af290f512d915e8